### PR TITLE
feat: show a message when the transcode is killed

### DIFF
--- a/Jellyfin.Plugin.TranscodeKiller/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.TranscodeKiller/Configuration/PluginConfiguration.cs
@@ -16,4 +16,9 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the max height allowed to transcode.
     /// </summary>
     public int MaxHeight { get; set; } = 1080;
+
+    /// <summary>
+    /// Gets or sets the message shown to users whenever their session gets killed.
+    /// </summary>
+    public string Message { get; set; } = string.Empty;
 }

--- a/Jellyfin.Plugin.TranscodeKiller/Configuration/config.html
+++ b/Jellyfin.Plugin.TranscodeKiller/Configuration/config.html
@@ -22,6 +22,10 @@
                             <input is="emby-input" type="text" id="txtMaxHeight" required placeholder="1080" label="Maximum Height:" />
                             <div class="fieldDescription">The maximum video height that is allowed to transcode.</div>
                         </div>
+                        <div class="inputContainer">
+                            <input is="emby-input" type="text" id="txtMessage" label="Kill Message:"/>
+                            <div class="fieldDescription">This message is shown to the user when their transcode session is killed. Leave empty to disable.</div>
+                        </div>
                     </div>
                     <div>
                         <button is="emby-button" type="submit" data-theme="b" class="raised button-submit block">
@@ -43,6 +47,7 @@
 
             txtMaxWidth: document.querySelector("#txtMaxWidth"),
             txtMaxHeight: document.querySelector("#txtMaxHeight"),
+            txtMessage: document.querySelector("#txtMessage"),
         };
 
         document.querySelector('.esqConfigurationPage').addEventListener("pageshow", function () {
@@ -54,6 +59,7 @@
             window.ApiClient.getPluginConfiguration(TranscodeKillerConfigurationPage.pluginUniqueId).then(function (config) {
                 TranscodeKillerConfigurationPage.txtMaxWidth.value = config.MaxWidth;
                 TranscodeKillerConfigurationPage.txtMaxHeight.value = config.MaxHeight;
+                TranscodeKillerConfigurationPage.txtMessage.value = config.Message;
 
                 Dashboard.hideLoadingMsg();
             });
@@ -67,6 +73,7 @@
             window.ApiClient.getPluginConfiguration(TranscodeKillerConfigurationPage.pluginUniqueId).then(function (config) {
                 config.MaxWidth = parseInt(TranscodeKillerConfigurationPage.txtMaxWidth.value);
                 config.MaxHeight = parseInt(TranscodeKillerConfigurationPage.txtMaxHeight.value);
+                config.Message = TranscodeKillerConfigurationPage.txtMessage.value;
 
                 window.ApiClient.updatePluginConfiguration(TranscodeKillerConfigurationPage.pluginUniqueId, config).then(Dashboard.processPluginConfigurationUpdateResult);
             });

--- a/Jellyfin.Plugin.TranscodeKiller/KillerEntrypoint.cs
+++ b/Jellyfin.Plugin.TranscodeKiller/KillerEntrypoint.cs
@@ -58,6 +58,19 @@ public class KillerEntrypoint : IHostedService
                 e.PlaySessionId,
                 _ => true)
             .ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(PluginConfiguration.Message))
+        {
+            await _sessionManager.SendMessageCommand(
+                e.Session.Id,
+                e.Session.Id,
+                new MessageCommand
+                {
+                    Text = PluginConfiguration.Message,
+                    TimeoutMs = 5000
+                },
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Fixes #2. Adds an optional message shown to the user whenever their transcode is killed. Not sure how well supported the built-in Jellyfin messages are, but the web client does at least support them.

I plucked the 5000ms timeout from the Jellyfin admin dashboard message button.